### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,3 +15,7 @@ python:
 sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: true
+
+formats:
+  - pdf
+  - epub


### PR DESCRIPTION
Added formats as explained in https://docs.readthedocs.io/en/stable/tutorial/index.html#enabling-pdf-and-epub-builds